### PR TITLE
Add Swap method to fix build

### DIFF
--- a/kaldi_io/kaldi_io_internal.cpp
+++ b/kaldi_io/kaldi_io_internal.cpp
@@ -112,6 +112,10 @@ class PyObjectHolder {
 
   void Clear() {}
 
+  void Swap(PyObjectHolder * another) {
+    std::swap(t_, another->t_);
+  }
+
   ~PyObjectHolder() {}
 
 private:
@@ -252,6 +256,10 @@ class PythonToKaldiHolder {
   const T &Value() const {return t_;}  // if t is a pointer, would return *t_;
 
   void Clear() {}
+
+  void Swap(PythonToKaldiHolder<Converter> * another) {
+    std::swap(t_, another->t_);
+  }
 
   ~PythonToKaldiHolder() {}
 


### PR DESCRIPTION
After [this commit](https://github.com/kaldi-asr/kaldi/commit/99a39ff602738fea293370f8d58fec15b7c60104) in Kaldi master it is necessary to add `Swap` method to some of the classes in `kaldi_io_internal.cpp`. 
