### PR TITLE
Remove IsKaldiError calls and change the override in setup.py from build_py to build.

### DIFF
--- a/kaldi_io/kaldi_io_internal.cpp
+++ b/kaldi_io/kaldi_io_internal.cpp
@@ -72,8 +72,7 @@ class PyObjectHolder {
       return os.good();
 
     } catch (const std::exception &e) {
-      KALDI_WARN<< "Exception caught writing Table object: " << e.what();
-      if (!kaldi::IsKaldiError(e.what())) {std::cerr << e.what();}
+      KALDI_WARN<< "Exception caught writing Table object. " << e.what();
       return false;  // Write failure.
     }
   }
@@ -100,8 +99,7 @@ class PyObjectHolder {
       }
       return true;
     } catch (std::exception &e) {
-      KALDI_WARN << "Exception caught reading Table object";
-      if (!kaldi::IsKaldiError(e.what())) {std::cerr << e.what();}
+      KALDI_WARN << "Exception caught reading Table object. " << e.what();
       return false;
     }
   }
@@ -243,8 +241,7 @@ class PythonToKaldiHolder {
       auto_ptr<typename HW::T> obj(Converter::python_to_kaldi(t));
       return HW::Write(os, binary, (*obj));
     } catch (std::exception &e) {
-      KALDI_WARN << "Exception caught reading Table object";
-      if (!kaldi::IsKaldiError(e.what())) {std::cerr << e.what();}
+      KALDI_WARN << "Exception caught reading Table object. " << e.what();
       return false;
     }
   }

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,19 @@
 
 import os
 from distutils.core import setup
-from distutils.command.build_py import build_py
+from distutils.command.build import build
 
-class Make(build_py):
+class Make(build):
     def run(self):
         os.system("make")
-        build_py.run(self)
+        build.run(self)
 
 setup(name='kaldi-python',
       version='1.0',
       description='Python interface for kaldi iterators',
       author='Jan Chorowski',
       url='https://github.com/janchorowski/kaldi-python',
-      cmdclass={'build_py': Make},
+      cmdclass={'build': Make},
       packages=['kaldi_io', 'kaldi_argparse'],
       package_data={'kaldi_io': ['kaldi_io_internal.so']},
       scripts=['scripts/apply-global-cmvn.py',


### PR DESCRIPTION
This pull request removes IsKaldiError calls and changes the override in setup.py from build_py to build.

IsKaldiError function was recently removed from Kaldi. See https://github.com/kaldi-asr/kaldi/pull/755.

Overriding build_py in setup.py to call "make" was preventing kaldi_io_internal.so from being copied into the installation directory.
