### PR TITLE
Add python library directory to LDFLAGS.

### DIFF
--- a/kaldi_io/Makefile
+++ b/kaldi_io/Makefile
@@ -19,6 +19,7 @@ ADDLIBS = $(KALDI_SRC)/lm/kaldi-lm.a $(KALDI_SRC)/decoder/kaldi-decoder.a $(KALD
 
 TESTFILES =
 
+LDFLAGS += -L$(shell python -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LIBDIR'))")
 PYLIB = $(shell python-config --libs)
 PYINC = $(shell python-config --includes)
 NPINC = -I$(shell python -c 'import numpy; print(numpy.get_include())')
@@ -28,7 +29,7 @@ PYLIBS = kaldi_io_internal.so
 #include $(KALDI_SRC)/makefiles/default_rules.mk
 
 %.so: %.cpp
-		g++ -shared -o $@ -Wall -fPIC -I$(KALDI_SRC) $(PYINC) $(NPINC) $(CXXFLAGS) $< $(ADDLIBS) $(LDFLAGS) -L$(PYLIB) $(LOADLIBES) $(LDLIBS) -lpython2.7 -lboost_python -lboost_system 
+		g++ -shared -o $@ -Wall -fPIC -I$(KALDI_SRC) $(PYINC) $(NPINC) $(CXXFLAGS) $< $(ADDLIBS) $(LDFLAGS) $(PYLIB) $(LOADLIBES) $(LDLIBS) -lpython2.7 -lboost_python -lboost_system
 
 clean:
 	-rm -f *.o *.a *.so $(TESTFILES) $(BINFILES) $(TESTOUTPUTS) tmp* *.tmp


### PR DESCRIPTION
If there are multiple python distributions installed on the system, the dynamic library `kaldi_io_internal` can be linked against the wrong python library. This PR fixes the problem by adding the correct python library directory to `LDFLAGS`. I also tried using `python-config --ldflags` to determine the python library directory but that does not work with anaconda for some reason. Addresses #10.