### PR TITLE
Removed thread/kaldi-thread.a dependency in kaldi_io/Makefile

### DIFF
--- a/kaldi_io/Makefile
+++ b/kaldi_io/Makefile
@@ -15,7 +15,7 @@ OBJFILES =
 ADDLIBS = $(KALDI_SRC)/lm/kaldi-lm.a $(KALDI_SRC)/decoder/kaldi-decoder.a $(KALDI_SRC)/lat/kaldi-lat.a \
           $(KALDI_SRC)/hmm/kaldi-hmm.a $(KALDI_SRC)/transform/kaldi-transform.a $(KALDI_SRC)/gmm/kaldi-gmm.a \
 	      $(KALDI_SRC)/tree/kaldi-tree.a $(KALDI_SRC)/matrix/kaldi-matrix.a  $(KALDI_SRC)/util/kaldi-util.a \
-          $(KALDI_SRC)/base/kaldi-base.a  $(KALDI_SRC)/thread/kaldi-thread.a
+          $(KALDI_SRC)/base/kaldi-base.a
 
 TESTFILES =
 


### PR DESCRIPTION
Kaldi now uses STL thread support library instead of pthread, see [this commit](https://github.com/kaldi-asr/kaldi/commit/6cc8e3ad79fe1a720451676b5b17866f3729d411).
In particular, thread/kaldi-thread.a was removed, preventing kaldi_io from compiling.